### PR TITLE
Replace options with version 3 equivalents

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,14 +22,10 @@ module.exports = function(command, opt){
 	if (typeof opt.development === 'undefined') { opt.development = false; }
 
 	// Behat Options: specific to Behat */
-	if (typeof opt.dryRun === 'undefined') { opt.dryRun = false; }             // --format='format'
+	if (typeof opt.dryRun === 'undefined') { opt.dryRun = false; }          // --format='format'
 	if (typeof opt.format === 'undefined') { opt.format = ''; }             // --format='format'
-	if (typeof opt.features === 'undefined') { opt.features = ''; }         // features='features'
-	if (typeof opt.showTime === 'undefined') { opt.showTime = true; }       // --no-time
-	if (typeof opt.ansi === 'undefined') { opt.ansi = true; }               // --no-ansi
-	if (typeof opt.showPaths === 'undefined') { opt.showPaths = true; }     // --no-paths
-	if (typeof opt.multiline === 'undefined') { opt.multiline = true; }     // --multiline
-	if (typeof opt.expand === 'undefined') { opt.expand = true; }           // --no-expand
+	if (typeof opt.paths === 'undefined') { opt.paths = ''; }               // paths='features'
+	if (typeof opt.colors === 'undefined') { opt.colors = true; }           // --no-colors
 	if (typeof opt.definitions === 'undefined') { opt.definitions = '-d'; } // --definitions="=d"
 	if (typeof opt.name === 'undefined') { opt.name = ''; }                 // --name
 	if (typeof opt.tags === 'undefined') { opt.tags = ''; }                 // --tags
@@ -55,16 +51,13 @@ module.exports = function(command, opt){
 		var cmd = opt.clear ? 'clear && ' + command : command;
 
 		// integrate options
-		cmd = opt.ansi ? cmd += ' --ansi' : cmd += ' --no-ansi';
+		cmd = opt.colors ? cmd += ' --colors' : cmd += ' --no-colors';
 
 		if(opt.dryRun) { cmd += ' --dry-run'; }
-		if(! opt.showTime) { cmd += ' --no-time'; }
-		if(! opt.showPaths) { cmd += ' --no-paths'; }
-		if(! opt.expand) { cmd += ' --no-expand'; }
 		if(opt.strict) { cmd += ' --strict'; }
 		if(opt.stopOnFail) { cmd += ' --stop-on-failure'; }
 		if(opt.configFile !== '') { cmd += ' --config=' + opt.configFile; }
-		if(opt.profile !== '') { cmd += ' --config=' + opt.profile; }
+		if(opt.profile !== '') { cmd += ' --profile=' + opt.profile; }
 
 		if(counter === 0) {
 			counter++;


### PR DESCRIPTION
This plugin doesn't work with behat v3 due to some options being change/removed.

I've renamed some accordingly and removed ones which I couldn't see are still options in v3 of behat.

It is probably worth running separate branches for v2 and v3 of behat. 
